### PR TITLE
fix: configure yt-dlp to use Node.js as JS runtime for YouTube

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,8 @@ COPY . .
 
 RUN npm install && npm run build && pip install --break-system-packages "yt-dlp[default]"
 
-# Configure yt-dlp to use Node.js (already in container) as its JS runtime
-# Required for YouTube extraction (EJS challenge solving)
-RUN mkdir -p /etc/yt-dlp && echo "--js-runtimes node" > /etc/yt-dlp/config
+# yt-dlp configuration
+COPY yt-dlp.conf /etc/yt-dlp/config
 
 # Make scripts executable
 RUN chmod +x /usr/src/app/docker-entrypoint.sh /usr/src/app/scripts/update-ytdlp.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ COPY . .
 
 RUN npm install && npm run build && pip install --break-system-packages "yt-dlp[default]"
 
+# Configure yt-dlp to use Node.js (already in container) as its JS runtime
+# Required for YouTube extraction (EJS challenge solving)
+RUN mkdir -p /etc/yt-dlp && echo "--js-runtimes node" > /etc/yt-dlp/config
+
 # Make scripts executable
 RUN chmod +x /usr/src/app/docker-entrypoint.sh /usr/src/app/scripts/update-ytdlp.sh
 

--- a/yt-dlp.conf
+++ b/yt-dlp.conf
@@ -1,0 +1,1 @@
+--js-runtimes node


### PR DESCRIPTION
yt-dlp now requires an external JS runtime for YouTube extraction (EJS challenge solving). Only deno is enabled by default, but Node.js is already in the container.

Adds a yt-dlp config file at `/etc/yt-dlp/config` with `--js-runtimes node` so it uses the existing Node 23 instead of requiring a separate deno install.

Fixes the `No supported JavaScript runtime could be found` error on YouTube downloads.