### PR TITLE
Add typing indicator and fix reply-to-message

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -454,19 +454,19 @@ const sendMediaAlbum = async (
         { source: fs.createReadStream(file.path) },
         {
           caption,
-          reply_parameters: { message_id: replyToMessageId },
-        }
+          reply_to_message_id: replyToMessageId,
+        } as any
       );
     } else {
       await ctx.replyWithVideo(
         { source: fs.createReadStream(file.path) },
         {
           caption,
-          reply_parameters: { message_id: replyToMessageId },
+          reply_to_message_id: replyToMessageId,
           supports_streaming: true,
           width: file.width,
           height: file.height,
-        }
+        } as any
       );
     }
     return;
@@ -502,8 +502,8 @@ const sendMediaAlbum = async (
     });
 
     await ctx.replyWithMediaGroup(mediaGroup, {
-      reply_parameters: { message_id: replyToMessageId },
-    });
+      reply_to_message_id: replyToMessageId,
+    } as any);
   }
 };
 
@@ -598,6 +598,12 @@ bot.on(message("text"), async (ctx) => {
   if (matches.length === 0) return;
 
   const tempDir = createTempDir();
+
+  // Keep sending typing indicator while processing (expires after 5s)
+  const chatActionInterval = setInterval(() => {
+    ctx.sendChatAction("typing").catch(() => {});
+  }, 4000);
+  await ctx.sendChatAction("typing");
 
   try {
     if (matches.length === 1) {
@@ -725,6 +731,8 @@ bot.on(message("text"), async (ctx) => {
       await ctx.reply("Error processing your request.");
     }
   } finally {
+    // Stop typing indicator
+    clearInterval(chatActionInterval);
     // Clean up temp directory (contains all downloaded files)
     cleanupTempDir(tempDir);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -454,6 +454,7 @@ const sendMediaAlbum = async (
         { source: fs.createReadStream(file.path) },
         {
           caption,
+          // Telegraf types don't include reply_to_message_id but the API supports it
           reply_to_message_id: replyToMessageId,
         } as any
       );
@@ -462,6 +463,7 @@ const sendMediaAlbum = async (
         { source: fs.createReadStream(file.path) },
         {
           caption,
+          // Telegraf types don't include reply_to_message_id but the API supports it
           reply_to_message_id: replyToMessageId,
           supports_streaming: true,
           width: file.width,
@@ -501,6 +503,7 @@ const sendMediaAlbum = async (
       }
     });
 
+    // Telegraf types don't include reply_to_message_id but the API supports it
     await ctx.replyWithMediaGroup(mediaGroup, {
       reply_to_message_id: replyToMessageId,
     } as any);


### PR DESCRIPTION
## Changes

- Show "typing" indicator while downloading (refreshes every 4s to stay visible)
- Use `reply_to_message_id` to properly reply to the original message
- Clean up interval in finally block

Tested on local bot - both features work correctly.