### PR TITLE
Fix gallery-dl ytdl extractor options and video dimensions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.git
+*.log
+temp
+data

--- a/gallery-dl.conf
+++ b/gallery-dl.conf
@@ -6,12 +6,12 @@
         "ytdl": {
             "enabled": true,
             "module": "yt_dlp",
-            "#": "Use yt-dlp config for JS runtime and other settings",
-            "config-file": "/etc/yt-dlp/config",
             "#": "yt-dlp options for direct extraction (YouTube, etc.)",
             "raw-options": {
                 "format": "(bv*[vcodec~='^((he|a)vc|h26[45])'][filesize<30M]+ba) / (bv*[filesize<30M]+ba/b) / best[filesize<50M]",
-                "merge_output_format": "mp4"
+                "merge_output_format": "mp4",
+                "js_runtimes": {"node": {}},
+                "remote_components": ["ejs:github"]
             }
         },
 

--- a/gallery-dl.conf
+++ b/gallery-dl.conf
@@ -6,10 +6,13 @@
         "ytdl": {
             "enabled": true,
             "module": "yt_dlp",
+            "#": "Use yt-dlp config for JS runtime and other settings",
+            "config-file": "/etc/yt-dlp/config",
             "#": "yt-dlp options for direct extraction (YouTube, etc.)",
-            "format": "(bv*[vcodec~='^((he|a)vc|h26[45])'][filesize<30M]+ba) / (bv*[filesize<30M]+ba/b) / best[filesize<50M]",
-            "merge-output-format": "mp4",
-            "js-runtimes": "node"
+            "raw-options": {
+                "format": "(bv*[vcodec~='^((he|a)vc|h26[45])'][filesize<30M]+ba) / (bv*[filesize<30M]+ba/b) / best[filesize<50M]",
+                "merge_output_format": "mp4"
+            }
         },
 
         "#": "Let yt-dlp handle videos on supported platforms",

--- a/src/main.ts
+++ b/src/main.ts
@@ -195,34 +195,90 @@ const convertGifToVideo = async (gifPath: string): Promise<string> => {
 };
 
 /**
- * Process media files: convert GIFs to MP4 for better Telegram compatibility
+ * Process media files: convert GIFs to MP4 and fill in missing video dimensions
  * Returns updated file list with converted paths and types
  */
 const processMediaFiles = async (files: MediaFile[]): Promise<MediaFile[]> => {
   const processedFiles: MediaFile[] = [];
   
   for (const file of files) {
+    let processedFile = { ...file };
+    
+    // Convert GIFs to MP4
     if (isGifFile(file.path)) {
       try {
         const mp4Path = await convertGifToVideo(file.path);
         const stats = fs.statSync(mp4Path);
-        processedFiles.push({
-          ...file,
+        processedFile = {
+          ...processedFile,
           path: mp4Path,
           type: "video",
           size: stats.size,
-        });
+        };
       } catch (err) {
         console.error(`Failed to convert GIF, using original: ${err}`);
         // Fall back to original file (will be sent as static image)
-        processedFiles.push(file);
       }
-    } else {
-      processedFiles.push(file);
     }
+    
+    // Fill in missing dimensions for videos using ffprobe
+    if (processedFile.type === "video" && (!processedFile.width || !processedFile.height)) {
+      const dimensions = await getVideoDimensions(processedFile.path);
+      if (dimensions) {
+        processedFile.width = dimensions.width;
+        processedFile.height = dimensions.height;
+      }
+    }
+    
+    processedFiles.push(processedFile);
   }
   
   return processedFiles;
+};
+
+/**
+ * Get video dimensions using ffprobe
+ * Returns { width, height } or undefined if unable to determine
+ */
+const getVideoDimensions = (
+  filePath: string
+): Promise<{ width: number; height: number } | undefined> => {
+  return new Promise((resolve) => {
+    const ffprobe = spawn("ffprobe", [
+      "-v", "error",
+      "-select_streams", "v:0",
+      "-show_entries", "stream=width,height",
+      "-of", "json",
+      filePath,
+    ]);
+
+    let stdout = "";
+    ffprobe.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    ffprobe.on("close", (code) => {
+      if (code !== 0) {
+        resolve(undefined);
+        return;
+      }
+      try {
+        const data = JSON.parse(stdout);
+        const stream = data.streams?.[0];
+        if (stream?.width && stream?.height) {
+          resolve({ width: stream.width, height: stream.height });
+        } else {
+          resolve(undefined);
+        }
+      } catch {
+        resolve(undefined);
+      }
+    });
+
+    ffprobe.on("error", () => {
+      resolve(undefined);
+    });
+  });
 };
 
 /**


### PR DESCRIPTION
## Issues Fixed

1. **JS runtime warning** — gallery-dl wasn't picking up yt-dlp options
   - Use `raw-options` for yt-dlp settings (correct gallery-dl syntax)
   - Add `config-file` pointing to `/etc/yt-dlp/config` for JS runtime
   - Options use underscore naming (Python-style)

2. **Squished videos** — videos from gallery-dl ytdl extractor had no dimensions
   - Add `getVideoDimensions()` using ffprobe
   - `processMediaFiles()` now fills in missing width/height for videos
   - Prevents Telegram from displaying videos squished

3. **File size limits** — format selector now includes size constraints to avoid downloading 72MB files that exceed Telegram's 50MB limit