### PR TITLE
Fix MP4 output and thumbnail embedding for gallery-dl

### DIFF
--- a/gallery-dl.conf
+++ b/gallery-dl.conf
@@ -7,9 +7,10 @@
             "enabled": true,
             "module": "yt_dlp",
             "#": "yt-dlp options for direct extraction (YouTube, etc.)",
+            "cmdline-args": "--merge-output-format mp4 --embed-thumbnail --convert-thumbnails jpg --audio-multistreams",
             "raw-options": {
-                "format": "(bv*[vcodec~='^((he|a)vc|h26[45])'][filesize<30M]+ba) / (bv*[filesize<30M]+ba/b) / best[filesize<50M]",
-                "merge_output_format": "mp4",
+                "format": "(bv*[vcodec~='^((he|a)vc|h26[45])'][filesize<30M]+ba[acodec~='^(mp4a|aac)']) / (bv*[vcodec~='^((he|a)vc|h26[45])'][filesize<30M]+ba) / (bv*[filesize<30M]+ba) / best[filesize<50M]",
+                "postprocessor_args": {"Merger": ["-c:a", "aac", "-b:a", "128k"]},
                 "js_runtimes": {"node": {}},
                 "remote_components": ["ejs:github"]
             }


### PR DESCRIPTION
The previous fix for js_runtimes resulted in MKV output because:
- Opus audio isn't supported in MP4 containers
- ffmpeg defaults to MKV when it can't put Opus in MP4

This fix:
- Adds cmdline-args for `--merge-output-format mp4 --embed-thumbnail --convert-thumbnails jpg`
- Adds postprocessor to transcode Opus audio to AAC
- Updates format selector to prefer AAC audio when available

Tested locally - produces proper MP4 with embedded thumbnail that works correctly in Telegram.