### PR TITLE
fix: quiet gallery-dl print output

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -446,6 +446,7 @@ const downloadWithGalleryDl = async (
     // --write-metadata writes .json files alongside downloads for metadata
     const galleryDl = execGalleryDl(
       [
+        "-q",
         "--config",
         "/etc/gallery-dl.conf",
         "-d",


### PR DESCRIPTION
Adds `-q` to the gallery-dl invocation so normal success output does not duplicate the explicit `--Print after:{_path}` line.

This fixes duplicate media entries caused by parsing the same downloaded file path twice.

## Verification
- reproduced duplicate stdout lines without `-q`
- reproduced single stdout line with `-q`
- `npm test` passes locally