### PR TITLE
fix: resolve Reddit share links before download

### DIFF
--- a/src/__tests__/reddit.test.ts
+++ b/src/__tests__/reddit.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolveRedditShareUrl } from "../helpers/reddit.js";
+
+describe("resolveRedditShareUrl", () => {
+  it("returns non-share reddit URLs unchanged", async () => {
+    const fetchMock = vi.fn();
+    const url = "https://www.reddit.com/r/funny/comments/abc123/some_title";
+
+    await expect(resolveRedditShareUrl(url, fetchMock as any)).resolves.toBe(url);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves reddit share URLs from final response URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      url: "https://www.reddit.com/r/funny/comments/abc123/some_title/?share_id=123&utm_source=share&utm_medium=ios_app#fragment",
+    });
+
+    await expect(
+      resolveRedditShareUrl(
+        "https://www.reddit.com/r/funny/s/AbCdEfGhIj",
+        fetchMock as any
+      )
+    ).resolves.toBe("https://www.reddit.com/r/funny/comments/abc123/some_title/");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://www.reddit.com/r/funny/s/AbCdEfGhIj",
+      { redirect: "follow" }
+    );
+  });
+
+  it("falls back to original URL when fetch has no final URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ url: "" });
+    const url = "https://www.reddit.com/r/funny/s/AbCdEfGhIj";
+
+    await expect(resolveRedditShareUrl(url, fetchMock as any)).resolves.toBe(url);
+  });
+});

--- a/src/helpers/reddit.ts
+++ b/src/helpers/reddit.ts
@@ -1,0 +1,38 @@
+const REDDIT_SHARE_URL_RE = /^https?:\/\/(?:www\.|old\.)?reddit\.com\/(?:r\/[^/]+\/|user\/[^/]+\/)?s\/[^/?#&]+/i;
+
+const stripTrackingParams = (url: string): string => {
+  const parsed = new URL(url);
+  parsed.search = "";
+  parsed.hash = "";
+  return parsed.toString();
+};
+
+/**
+ * Resolve Reddit share URLs (/s/...) to their canonical post URLs.
+ * gallery-dl's RedditRedirectExtractor currently exits successfully after the
+ * redirect but does not download anything, which makes the bot fall back to
+ * plain yt-dlp. A normal fetch with redirects followed still exposes the final
+ * canonical URL even when Reddit serves a verification page.
+ */
+export const resolveRedditShareUrl = async (
+  url: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<string> => {
+  if (!REDDIT_SHARE_URL_RE.test(url)) {
+    return url;
+  }
+
+  try {
+    const response = await fetchImpl(url, {
+      redirect: "follow",
+    });
+
+    if (response.url) {
+      return stripTrackingParams(response.url);
+    }
+  } catch {
+    // Best-effort normalization only; fall back to original URL.
+  }
+
+  return url;
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { spawn } from "child_process";
 
 import { patterns } from "./patterns";
 import { truncateWithEllipsis } from "./helpers/text";
+import { resolveRedditShareUrl } from "./helpers/reddit";
 import { VideoMetadata } from "./types";
 import {
   initCache,
@@ -914,22 +915,27 @@ const processUrl = async (
   pattern: (typeof patterns)[0],
   tempDir: string
 ): Promise<DownloadResult> => {
+  const normalizedUrl = await resolveRedditShareUrl(url);
+  if (normalizedUrl !== url) {
+    console.log(formatLog(ctx, `Resolved Reddit share URL: ${url} -> ${normalizedUrl}`));
+  }
+
   // Try gallery-dl first
   try {
-    const result = await downloadWithGalleryDl(ctx, url, tempDir);
+    const result = await downloadWithGalleryDl(ctx, normalizedUrl, tempDir);
     if (result.files.length > 0) {
       return result;
     }
   } catch (error: any) {
     console.log(
-      formatLog(ctx, `gallery-dl failed for ${url}: ${error.message}`)
+      formatLog(ctx, `gallery-dl failed for ${normalizedUrl}: ${error.message}`)
     );
     // Continue to yt-dlp fallback
   }
 
   // Fall back to yt-dlp
-  console.log(formatLog(ctx, `Falling back to yt-dlp for ${url}`));
-  const { path: videoPath, metadata } = await processVideo(ctx, url, pattern, tempDir);
+  console.log(formatLog(ctx, `Falling back to yt-dlp for ${normalizedUrl}`));
+  const { path: videoPath, metadata } = await processVideo(ctx, normalizedUrl, pattern, tempDir);
 
   const stats = fs.statSync(videoPath);
   return {


### PR DESCRIPTION
## Summary
- resolve Reddit `/s/...` share URLs to their canonical `/comments/...` URL before downloading
- strip Reddit share tracking params from the resolved URL
- add tests for the share-link resolver

## Why
`gallery-dl`'s Reddit redirect extractor can return successfully without downloading anything for share links, which pushes the bot into the yt-dlp fallback path. Normalizing the URL first keeps Reddit share links on the intended gallery-dl path.

## Testing
- npm test
- npm run build
