### PR TITLE
feat: support Reddit OAuth gallery-dl overrides via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,10 @@ CACHE_DB_PATH=./data/cache.db
 CACHE_MAX_ENTRIES=100000
 # Run eviction check every N cache writes (default: 100)
 CACHE_EVICT_WRITES=100
+
+# Optional Reddit OAuth overrides passed to gallery-dl at runtime
+# When GDL_REDDIT_REFRESH_TOKEN is set, the bot automatically enables
+# extractor.reddit.api=oauth unless GDL_REDDIT_API is set explicitly.
+GDL_REDDIT_API=oauth
+GDL_REDDIT_REFRESH_TOKEN=
+GDL_REDDIT_USER_AGENT=

--- a/src/__tests__/gallerydl-options.test.ts
+++ b/src/__tests__/gallerydl-options.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { getGalleryDlCliOptionsFromEnv } from "../helpers/gallerydl.js";
+
+describe("getGalleryDlCliOptionsFromEnv", () => {
+  it("returns no overrides when env vars are missing", () => {
+    expect(getGalleryDlCliOptionsFromEnv({})).toEqual([]);
+  });
+
+  it("enables oauth automatically when only refresh token is set", () => {
+    expect(
+      getGalleryDlCliOptionsFromEnv({
+        GDL_REDDIT_REFRESH_TOKEN: "token123",
+      })
+    ).toEqual([
+      "-o",
+      "extractor.reddit.api=oauth",
+      "-o",
+      "extractor.reddit.refresh-token=token123",
+    ]);
+  });
+
+  it("includes user agent override when provided", () => {
+    expect(
+      getGalleryDlCliOptionsFromEnv({
+        GDL_REDDIT_USER_AGENT: "Python:mediarelaybot:v1.0 (by /u/test)",
+      })
+    ).toEqual([
+      "-o",
+      "extractor.reddit.headers.user-agent=Python:mediarelaybot:v1.0 (by /u/test)",
+    ]);
+  });
+
+  it("respects explicit api override", () => {
+    expect(
+      getGalleryDlCliOptionsFromEnv({
+        GDL_REDDIT_API: "oauth",
+        GDL_REDDIT_REFRESH_TOKEN: "token123",
+        GDL_REDDIT_USER_AGENT: "ua",
+      })
+    ).toEqual([
+      "-o",
+      "extractor.reddit.api=oauth",
+      "-o",
+      "extractor.reddit.refresh-token=token123",
+      "-o",
+      "extractor.reddit.headers.user-agent=ua",
+    ]);
+  });
+
+  it("ignores blank values", () => {
+    expect(
+      getGalleryDlCliOptionsFromEnv({
+        GDL_REDDIT_API: "  ",
+        GDL_REDDIT_REFRESH_TOKEN: " ",
+        GDL_REDDIT_USER_AGENT: "",
+      })
+    ).toEqual([]);
+  });
+});

--- a/src/helpers/gallerydl.ts
+++ b/src/helpers/gallerydl.ts
@@ -1,0 +1,28 @@
+const trimToUndefined = (value?: string): string | undefined => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+export const getGalleryDlCliOptionsFromEnv = (
+  env: Record<string, string | undefined> = process.env
+): string[] => {
+  const refreshToken = trimToUndefined(env.GDL_REDDIT_REFRESH_TOKEN);
+  const userAgent = trimToUndefined(env.GDL_REDDIT_USER_AGENT);
+  const api = trimToUndefined(env.GDL_REDDIT_API) || (refreshToken ? "oauth" : undefined);
+
+  const args: string[] = [];
+
+  if (api) {
+    args.push("-o", `extractor.reddit.api=${api}`);
+  }
+
+  if (refreshToken) {
+    args.push("-o", `extractor.reddit.refresh-token=${refreshToken}`);
+  }
+
+  if (userAgent) {
+    args.push("-o", `extractor.reddit.headers.user-agent=${userAgent}`);
+  }
+
+  return args;
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { spawn } from "child_process";
 
 import { patterns } from "./patterns";
 import { truncateWithEllipsis } from "./helpers/text";
+import { getGalleryDlCliOptionsFromEnv } from "./helpers/gallerydl";
 import { resolveRedditShareUrl } from "./helpers/reddit";
 import { VideoMetadata } from "./types";
 import {
@@ -450,6 +451,7 @@ const downloadWithGalleryDl = async (
         "-q",
         "--config",
         "/etc/gallery-dl.conf",
+        ...getGalleryDlCliOptionsFromEnv(),
         "-d",
         tempDir,
         "--Print",


### PR DESCRIPTION
## Summary
- add a helper that converts Reddit gallery-dl env vars into CLI `-o` overrides
- append those overrides when invoking gallery-dl
- document the new env vars in `.env.example`
- add tests for the env-to-CLI mapping

## Supported env vars
- `GDL_REDDIT_API`
- `GDL_REDDIT_REFRESH_TOKEN`
- `GDL_REDDIT_USER_AGENT`

If `GDL_REDDIT_REFRESH_TOKEN` is set and `GDL_REDDIT_API` is not, the bot automatically enables `extractor.reddit.api=oauth`.

## Why
This keeps Reddit OAuth secrets out of the committed `gallery-dl.conf` while still making it easy to configure OAuth in a private container/runtime environment.

## Testing
- npm test
- npm run build
